### PR TITLE
Plaintext subpods may contain empty elements

### DIFF
--- a/lib/parse.js
+++ b/lib/parse.js
@@ -6,14 +6,19 @@ const assign = utils.assign;
 const isEmpty = utils.isEmpty;
 const typedVal = utils.typedVal;
 
-const COLUMN_DELIMITER = ' | ';
+const COLUMN_DELIMITER = '|';
 
 function processPlaintext(plaintext) {
   if (!plaintext) return plaintext;
 
   let lines = plaintext.split('\n');
-  return lines.map(line =>
-    line.split(COLUMN_DELIMITER).map(column => column.trim()));
+
+  // Trim whitespace out of individual lines;
+  // remove empty leftover lines
+  return lines.map(line => line.split(COLUMN_DELIMITER)
+                               .map(column => column.trim())
+                               .filter(column => column))
+              .filter(column => column.length > 0);
 }
 
 function getLinks(pod) {

--- a/lib/parse.js
+++ b/lib/parse.js
@@ -15,10 +15,8 @@ function processPlaintext(plaintext) {
 
   // Trim whitespace out of individual lines;
   // remove empty leftover lines
-  return lines.map(line => line.split(COLUMN_DELIMITER)
-                               .map(column => column.trim())
-                               .filter(column => column))
-              .filter(column => column.length > 0);
+  return lines.map(line => parseLine(line))
+              .filter(column => !isEmpty(column));
 }
 
 function getLinks(pod) {
@@ -117,4 +115,13 @@ function getResultData(xmldoc) {
   });
 
   return data;
+}
+
+function parseLine(line, columnDelimiter) {
+  columnDelimiter = columnDelimiter || COLUMN_DELIMITER;
+
+  let columns = line.split(columnDelimiter)
+                    .map(column => column.trim());
+
+  return columns.filter(column => !isEmpty(column));
 }

--- a/lib/parse.js
+++ b/lib/parse.js
@@ -120,8 +120,7 @@ function getResultData(xmldoc) {
 function parseLine(line, columnDelimiter) {
   columnDelimiter = columnDelimiter || COLUMN_DELIMITER;
 
-  let columns = line.split(columnDelimiter)
-                    .map(column => column.trim());
-
-  return columns.filter(column => !isEmpty(column));
+  return line.split(columnDelimiter)
+             .map(column => column.trim())
+             .filter(column => !isEmpty(column));
 }


### PR DESCRIPTION
See [issue](https://github.com/vladimyr/wolfram-query/issues/1)
